### PR TITLE
Fixed version issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,8 +53,8 @@
 				<configuration>
 					<showWarnings>true</showWarnings>
 					<showDeprecation>true</showDeprecation>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.7</source>
+					<target>1.7</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,9 @@
 						</goals>
 					</execution>
 				</executions>
+				<configuration>
+					<source>7</source>
+				</configuration>
 			</plugin>
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
This fix just adds a version configuration to the javadoc tool. Otherwise, newer Java-Versions same issue arises as with vfsjfilechooser2. I don't see a reason for commenting out the javadoc plugin as this merely sets the --source option of the javadoc tool. https://docs.oracle.com/javase/1.5.0/docs/tooldocs/windows/javadoc.html#javadocoptions

Additionally, the compliance level of the module is set to 1.7 to be compliant to the API used in the code.

You may or may not set both to Java 6, however, current IntelliJ versions will not compile the code without further intervention.